### PR TITLE
update brew install command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@
 
 ### macOS
 
-You can download the [latest release][releases] or install it with [homebrew cask](https://caskroom.io/): `brew cask install healthi`.
+You can download the [latest release][releases] or install it with [homebrew cask](https://caskroom.io/): `brew install --cask healthi`.
 
 ### Linux
 


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524